### PR TITLE
feat: wire all remaining unused i18n keys

### DIFF
--- a/.artefacts/BRIEF.md
+++ b/.artefacts/BRIEF.md
@@ -11,11 +11,11 @@ Interactive [Management 3.0 Moving Motivators](https://management30.com/practice
 - [x] English + Russian locales (`src/i18n/en.json`, `ru.json`)
 - [x] Responsive layout and touch-friendly drag-and-drop
 - [x] Share / copy results as image — html2canvas captures results div to clipboard PNG (or downloads if clipboard API unavailable)
-- [ ] Optional insight line — `results.insight` unused in `src/`
-- [ ] Facilitation guide screen — `facilitation.*` strings unused
-- [ ] Team session phase copy — `team.phase.lobby` / `ranking` / `assessing`, `team.waitingFor`, `team.facilitationGuide` unused; only `team.phase.revealed` wired
-- [ ] Home copy — `home.team` unused (host/join/unavailable used)
-- [ ] Header language toggle uses raw `EN`/`RU` in `App.tsx` instead of `lang.en` / `lang.ru`
+- [x] Optional insight line — `results.insight` shown below interpretation panel when change is assessed
+- [x] Facilitation guide screen — FacilitationGuide.tsx wired in App.tsx; linked from HomeScreen
+- [x] Team session phase copy — lobby/ranking/assessing/revealed all wired; `team.waitingFor` shown when no participants yet
+- [x] Home team section label — `home.team` used as section heading above host/join buttons
+- [x] Header language toggle — uses `lang.en` / `lang.ru` i18n keys
 
 ## Backlog
 
@@ -27,6 +27,11 @@ Interactive [Management 3.0 Moving Motivators](https://management30.com/practice
 - Submodule `agentic-kit` remote: `bthos/agentic-kit` (see `.gitmodules`).
 
 ## Agent Log
+
+### 2026-04-20 — feat: wire all remaining unused i18n keys
+- Done: `results.insight` paragraph in ResultsView.tsx (shown when change assessed); `home.team` heading in HomeScreen.tsx team section; `lang.en`/`lang.ru` in App.tsx header toggle; `team.waitingFor` in host lobby when no participants; `team.phase.lobby` waiting screen for participants; `team.phase.ranking`/`assessing` phase badges in team-play.
+- Remaining features: none — all BRIEF features implemented.
+- Next task: check needs-review issues for human feedback; run research cycle for market/integration/UX improvements.
 
 ### 2026-04-19 — feat: share / copy results as image
 - Done: installed html2canvas; added `handleShare` in `ResultsView.tsx` — captures container div to PNG, writes to clipboard via ClipboardItem, falls back to download link; share button added beside Start Over with `t('results.share')` label and spinner state.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,7 @@ function App() {
             onClick={() => i18n.changeLanguage(i18n.language.startsWith('ru') ? 'en' : 'ru')}
             className="text-sm text-gray-500 hover:text-gray-700 px-2 py-1 rounded hover:bg-gray-100 transition-colors"
           >
-            {i18n.language.startsWith('ru') ? 'EN' : 'RU'}
+            {i18n.language.startsWith('ru') ? t('lang.en') : t('lang.ru')}
           </button>
         </div>
       </header>

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -44,6 +44,7 @@ export default function HomeScreen({ onSolo, onHost, onJoin, onFacilitation }: P
 
         {/* Team */}
         <div className="flex flex-col gap-2">
+          <span className="font-semibold text-gray-900 text-lg px-1">🤝 {t('home.team')}</span>
           <button
             onClick={firebaseReady ? onHost : undefined}
             disabled={!firebaseReady}

--- a/src/components/ResultsView.tsx
+++ b/src/components/ResultsView.tsx
@@ -222,6 +222,10 @@ export default function ResultsView({ motivators, change, onReset, onInfo }: Pro
       {/* Interpretation */}
       <InterpretationPanel motivators={motivators} change={change} onInfo={onInfo} />
 
+      {change && (
+        <p className="text-xs text-gray-400 leading-relaxed">{t('results.insight')}</p>
+      )}
+
       <div className="flex flex-wrap gap-3">
         <button onClick={onReset} className="px-6 py-2 text-sm font-medium border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors">
           ↩ {t('results.startOver')}

--- a/src/components/TeamSession.tsx
+++ b/src/components/TeamSession.tsx
@@ -268,9 +268,13 @@ export default function TeamSession({
         <div className="text-6xl font-mono font-bold text-brand-600 tracking-widest bg-brand-50 px-8 py-4 rounded-2xl">
           {pin}
         </div>
-        <p className="text-gray-500">
-          {completedCount}/{entries.length} {t('team.participants')} done
-        </p>
+        {entries.length === 0 ? (
+          <p className="text-gray-500">{t('team.waitingFor')}</p>
+        ) : (
+          <p className="text-gray-500">
+            {completedCount}/{entries.length} {t('team.participants')} done
+          </p>
+        )}
         {entries.map(([id, p]) => (
           <div key={id} className="flex items-center gap-2 text-sm text-gray-700">
             <span>{p.completed ? '✅' : '⏳'}</span>
@@ -324,28 +328,45 @@ export default function TeamSession({
 
   // ── PARTICIPANT play ────────────────────────────────────────────────────
   if (screen === 'team-play') {
-    if (sessionPhase === 'lobby' || sessionPhase === 'ranking') {
+    if (sessionPhase === 'lobby') {
       return (
-        <RankingBoard
-          motivators={motivators}
-          onChange={onMotivators}
-          onNext={() => setSessionPhase('assessing')}
-          onSkip={() => setSessionPhase('assessing')}
-          onBack={onBack}
-          onInfo={onInfo}
-        />
+        <div className="flex flex-col items-center gap-4 pt-16 text-gray-500">
+          <p className="text-lg font-medium">{t('team.phase.lobby')}</p>
+          <button onClick={onBack} className="text-sm text-gray-400 hover:text-gray-600">{t('common.back')}</button>
+        </div>
+      )
+    }
+    const phaseBadge = (key: string) => (
+      <p className="text-xs font-medium text-brand-500 uppercase tracking-wider mb-2">{t(key)}</p>
+    )
+    if (sessionPhase === 'ranking') {
+      return (
+        <div>
+          {phaseBadge('team.phase.ranking')}
+          <RankingBoard
+            motivators={motivators}
+            onChange={onMotivators}
+            onNext={() => setSessionPhase('assessing')}
+            onSkip={() => setSessionPhase('assessing')}
+            onBack={onBack}
+            onInfo={onInfo}
+          />
+        </div>
       )
     }
     return (
-      <ChangeAssessment
-        motivators={motivators}
-        change={change}
-        onChangeText={onChange}
-        onMotivatorChange={onMotivators}
-        onNext={handleParticipantDone}
-        onBack={() => setSessionPhase('ranking')}
-        onInfo={onInfo}
-      />
+      <div>
+        {phaseBadge('team.phase.assessing')}
+        <ChangeAssessment
+          motivators={motivators}
+          change={change}
+          onChangeText={onChange}
+          onMotivatorChange={onMotivators}
+          onNext={handleParticipantDone}
+          onBack={() => setSessionPhase('ranking')}
+          onInfo={onInfo}
+        />
+      </div>
     )
   }
 


### PR DESCRIPTION
- results.insight paragraph in ResultsView (shown when change assessed)
- home.team heading in HomeScreen team section
- lang.en/lang.ru keys in App.tsx header language toggle
- team.waitingFor in host lobby when no participants joined yet
- team.phase.lobby waiting screen for participants
- team.phase.ranking/assessing phase badges in team-play