### PR TITLE
feat: QR code sharing for team sessions (#11)

### DIFF
--- a/.artefacts/BRIEF.md
+++ b/.artefacts/BRIEF.md
@@ -29,6 +29,7 @@ Interactive [Management 3.0 Moving Motivators](https://management30.com/practice
 - [x] Sprint Metrics integration — writes `moving-motivators:motivationSnapshot` to localStorage when host reveals team session (top 3 motivators by aggregate rank, participant count, date, PIN as team name); "Send to Sprint Metrics" button in TeamResultsView encodes snapshot as base64 and opens Sprint Metrics with `?mm=<base64>` URL param; i18n key `team.sendToSprintMetrics` in all 4 locales (issue #14)
 - [x] Named session storage — "Save as…" button in ResultsView labels the current session in sessionHistory; label shown in SessionShiftPanel history list; each history entry has optional `label?: string` field; Restore button re-populates ranking board from any history entry; history cap increased from 5 to 20 (issue #34)
 - [x] PWA / offline support — `vite-plugin-pwa` with `generateSW` strategy; service worker caches app shell + fonts; offline banner shown app-wide when network drops; team session buttons disabled when offline; Web App Manifest with coral theme and SVG icon (issue #12)
+- [x] QR code sharing for team sessions — `qrcode.react` `<QRCodeSVG>` rendered in host lobby showing join URL (`?join=<PIN>`); hidden on screens < 480px; `team.scanToJoin` i18n key in all 4 locales; App.tsx reads `?join=` URL param on load and auto-navigates to join screen with PIN pre-filled (issue #11)
 
 ## localStorage keys
 
@@ -43,7 +44,7 @@ Interactive [Management 3.0 Moving Motivators](https://management30.com/practice
 <!-- Agent: append `needs-review` research issues here as `- [ ] #N …` -->
 - [x] [#9] Feature: ES + BE locale support (suite standard) — implemented 2026-05-01
 - [ ] [#10] Integration: Moving Motivators → Work Profiles (motivator snapshot)
-- [ ] [#11] Feature: QR code sharing for team sessions
+- [x] [#11] Feature: QR code sharing for team sessions — implemented 2026-06-16
 - [x] [#12] Feature: PWA / offline support for workshop use — implemented 2026-06-13
 - [ ] [#13] Feature: print / PDF export of results
 - [x] [#14] Integration: Moving Motivators → Sprint Metrics (motivation snapshot export) — implemented 2026-06-07
@@ -61,6 +62,11 @@ Interactive [Management 3.0 Moving Motivators](https://management30.com/practice
 - `.gitmodules` references `agentic-kit` (dev pipeline tooling, not used in build). CI workflow does not fetch submodules.
 
 ## Agent Log
+
+### 2026-06-16 — feat: QR code sharing for team sessions (issue #11)
+- Done: installed `qrcode.react@4.2.0`; in `TeamSession.tsx` — imported `QRCodeSVG` and added `initialJoinPin` prop; QR code block (`<QRCodeSVG>`, 140px, level M) rendered in host lobby below PIN display, hidden on screens < 480px via `hidden min-[480px]:flex`; `joinUrl` = `window.location.origin + import.meta.env.BASE_URL + '?join=' + pin`; `team.scanToJoin` label below QR in all 4 locales (EN/ES/RU/BE); in `App.tsx` — added `readJoinParam()` helper, `initialJoinPin` state, if `?join=` param present initial screen is `team-join` and PIN pre-filled in join form via prop; URL params cleared after read
+- Remaining approved: #10 (Work Profiles integration — motivator snapshot)
+- Next task: check issues for human feedback; implement #10 (Work Profiles integration — export motivator snapshot to work-profiles:motivatorSnapshot localStorage key, or deep-link to Work Profiles with snapshot encoded in URL)
 
 ### 2026-06-13 — feat: PWA / offline support (issue #12)
 - Done: installed `vite-plugin-pwa@1.3.0`; updated `vite.config.ts` with `VitePWA({ registerType: 'autoUpdate', generateSW })` — caches app shell + static assets + Google Fonts (CacheFirst, 365d TTL); Web App Manifest (`dist/manifest.webmanifest`) with name, short_name, coral theme_color `#FF6B5B`, `display: standalone`, `start_url/scope: /moving-motivators/`, SVG icon at `public/icons/icon.svg`; added `useOnlineStatus()` hook in `App.tsx` (listens to `window online/offline` events); offline amber banner shown below header when offline (`pwa.offlineBanner` i18n key in all 4 locales); `HomeScreen` accepts `isOnline` prop and short-circuits `firebaseReady` to false when offline, gracefully disabling team session buttons

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "html2canvas": "^1.4.1",
         "i18next": "^24.2.3",
         "i18next-browser-languagedetector": "^8.0.4",
+        "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-i18next": "^15.4.1"
@@ -6650,6 +6651,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "html2canvas": "^1.4.1",
     "i18next": "^24.2.3",
     "i18next-browser-languagedetector": "^8.0.4",
+    "qrcode.react": "^4.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-i18next": "^15.4.1"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,17 +33,28 @@ function readChangeParam(): string {
   }
 }
 
+function readJoinParam(): string {
+  try {
+    return new URLSearchParams(window.location.search).get('join') ?? ''
+  } catch {
+    return ''
+  }
+}
+
 function App() {
   const { t } = useTranslation()
   const isOnline = useOnlineStatus()
   const initialChange = readChangeParam()
-  const [screen, setScreen] = useState<Screen>(initialChange ? 'solo-rank' : 'home')
+  const initialJoinPin = readJoinParam()
+  const [screen, setScreen] = useState<Screen>(
+    initialChange ? 'solo-rank' : initialJoinPin ? 'team-join' : 'home'
+  )
   const [motivators, setMotivators] = useState<MotivatorItem[]>(defaultMotivatorItems())
   const [change, setChange] = useState(initialChange)
   const [infoMotivator, setInfoMotivator] = useState<MotivatorId | null>(null)
 
   useEffect(() => {
-    if (initialChange) {
+    if (initialChange || initialJoinPin) {
       window.history.replaceState({}, '', window.location.pathname)
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -150,6 +161,7 @@ function App() {
             change={change}
             onChange={setChange}
             onBack={reset}
+            initialJoinPin={initialJoinPin}
           />
         )}
       </main>

--- a/src/components/TeamSession.tsx
+++ b/src/components/TeamSession.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ref, set, onValue, push, update } from 'firebase/database'
+import { QRCodeSVG } from 'qrcode.react'
 import { getFirebaseDb } from '../firebase'
 import type { Screen, MotivatorItem, MotivatorId } from '../types'
 import { getMotivatorMeta, defaultMotivatorItems } from '../data/motivators'
@@ -18,6 +19,7 @@ interface Props {
   onChange: (s: string) => void
   onBack: () => void
   onInfo?: (id: MotivatorId) => void
+  initialJoinPin?: string
 }
 
 interface FirebaseParticipant {
@@ -332,10 +334,11 @@ export default function TeamSession({
   onChange,
   onBack,
   onInfo,
+  initialJoinPin = '',
 }: Props) {
   const { t } = useTranslation()
   const [pin, setPin] = useState('')
-  const [joinPin, setJoinPin] = useState('')
+  const [joinPin, setJoinPin] = useState(initialJoinPin)
   const [name, setName] = useState('')
   const [participantId, setParticipantId] = useState('')
   const [sessionPhase, setSessionPhase] = useState<'lobby' | 'ranking' | 'assessing' | 'revealed'>('lobby')
@@ -453,6 +456,7 @@ export default function TeamSession({
   if (screen === 'team-host') {
     const entries = Object.entries(participants)
     const completedCount = entries.filter(([, p]) => p.completed).length
+    const joinUrl = `${window.location.origin}${import.meta.env.BASE_URL}?join=${pin}`
 
     return (
       <div className="flex flex-col items-center gap-5 max-w-sm mx-auto pt-8">
@@ -463,6 +467,16 @@ export default function TeamSession({
             {pin}
           </div>
         </div>
+
+        {/* QR code — hidden on small screens (< 480px) where host's phone can't be shared) */}
+        {pin && (
+          <div className="hidden min-[480px]:flex flex-col items-center gap-2">
+            <div className="p-3 bg-white rounded-2xl shadow-sm border border-gray-100 dark:border-gray-800">
+              <QRCodeSVG value={joinUrl} size={140} level="M" />
+            </div>
+            <p className="text-xs text-gray-400 dark:text-gray-500">{t('team.scanToJoin')}</p>
+          </div>
+        )}
 
         {/* Phase: lobby — waiting for participants */}
         {sessionPhase === 'lobby' && (

--- a/src/i18n/be.json
+++ b/src/i18n/be.json
@@ -129,7 +129,8 @@
       "anonymize": "Ананімізаваць",
       "deanonymize": "Паказаць імёны"
     },
-    "sendToSprintMetrics": "Адправіць у Sprint Metrics"
+    "sendToSprintMetrics": "Адправіць у Sprint Metrics",
+    "scanToJoin": "Сканаваць для далучэння"
   },
   "motivators": {
     "curiosity": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -129,7 +129,8 @@
       "anonymize": "Anonymize Names",
       "deanonymize": "Show Names"
     },
-    "sendToSprintMetrics": "Send to Sprint Metrics"
+    "sendToSprintMetrics": "Send to Sprint Metrics",
+    "scanToJoin": "Scan to join"
   },
   "motivators": {
     "curiosity": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -129,7 +129,8 @@
       "anonymize": "Anonimizar Nombres",
       "deanonymize": "Mostrar Nombres"
     },
-    "sendToSprintMetrics": "Enviar a Sprint Metrics"
+    "sendToSprintMetrics": "Enviar a Sprint Metrics",
+    "scanToJoin": "Escanear para unirse"
   },
   "motivators": {
     "curiosity": {

--- a/src/i18n/ru.json
+++ b/src/i18n/ru.json
@@ -129,7 +129,8 @@
       "anonymize": "Анонимизировать",
       "deanonymize": "Показать имена"
     },
-    "sendToSprintMetrics": "Отправить в Sprint Metrics"
+    "sendToSprintMetrics": "Отправить в Sprint Metrics",
+    "scanToJoin": "Сканировать для входа"
   },
   "motivators": {
     "curiosity": {


### PR DESCRIPTION
Automated agent commit — see BRIEF.md.

## Changes
- Install `qrcode.react@4.2.0`
- Add QR code in host lobby showing join URL (`?join=<PIN>`), hidden on screens < 480px
- Add `team.scanToJoin` i18n key in all 4 locales (EN/ES/RU/BE)
- Read `?join=` URL param in App.tsx to auto-navigate to join screen with PIN pre-filled