### PR TITLE
feat: team motivator trend view in session history panel (#46)

### DIFF
--- a/.artefacts/BRIEF.md
+++ b/.artefacts/BRIEF.md
@@ -58,9 +58,9 @@ Interactive [Management 3.0 Moving Motivators](https://management30.com/practice
 - [x] [#20] Feature: facilitator timer for ranking and assessment phases — implemented 2026-05-30
 - [x] [#21] Feature: solo motivator shift tracking — compare sessions over time (implemented)
 - [x] [#22] Integration: Moving Motivators ↔ Change Planner — MM side implemented; Change Planner side (read ?mm_snapshot= and show motivator context sidebar) pending
-- [ ] [#46] Research: team motivator trend visualization across sessions
-- [ ] [#47] Research: export session history as JSON download
-- [ ] [#48] Research: multi-session motivator rank trend chart for solo mode
+- [x] [#46] Feature: team motivator trend visualization across sessions — implemented 2026-07-01
+- [ ] [#47] Research: export session history as JSON download — auto-approved 2026-07-01
+- [ ] [#48] Research: multi-session motivator rank trend chart for solo mode — auto-approved 2026-07-01
 - [ ] [#49] Research: first-run onboarding overlay for new users
 - [ ] [#50] Research: import session history from JSON (companion to #47 export)
 - [ ] [#51] Integration: Team Identity → Moving Motivators (pre-populate team name in team sessions)
@@ -73,6 +73,11 @@ Interactive [Management 3.0 Moving Motivators](https://management30.com/practice
 - `.gitmodules` references `agentic-kit` (dev pipeline tooling, not used in build). CI workflow does not fetch submodules.
 
 ## Agent Log
+
+### 2026-07-01 — feat: team motivator trend view in SessionHistoryPanel (issue #46)
+- Done: added List/Trend toggle to `SessionHistoryPanel` in `TeamSession.tsx`; trend view computes top-3 appearance frequency per motivator across all stored `moving-motivators:teamSessionHistory` entries and renders a frequency bar chart sorted by count descending; bars use each motivator's brand color; zero appearances shown greyed out; added 4 i18n keys (`team.history.list/trend/topMotivators/sessions`) in all 4 locales (EN/ES/BE/RU); auto-approved #47 and #48 (8 days stale research issues)
+- Remaining: #5 (favicon, awaiting `approved`); #16 (Dashboard side, agile-toolkit.github.io); #22 (Change Planner side, change-planner); #47 (JSON export, approved); #48 (solo rank trend table, approved); #49–#53 (needs-review)
+- Next task: implement #47 (JSON export — export button in SessionShiftPanel and SessionHistoryPanel using Blob/URL.createObjectURL, `results.exportHistory` + `team.history.export` i18n keys in all 4 locales) or #48 (solo rank trend table in SessionShiftPanel — compact motivator×session grid, last 6 sessions, green/red color coding)
 
 ### 2026-06-29 — research: #5 body update, new research issues #52–53
 - Done: updated #5 (favicon, research-more) issue body with finalized SVG design and clear implementation steps — all research questions resolved, awaiting `approved` label; created #52 (motivator coaching tips panel — personalized tips based on top 3 motivators in solo results, ~80 LOC new component); created #53 (Improvement Board → MM deep link — IB improvement card links to MM with `?change=<title>` pre-filled, zero MM-side changes needed as `?change=` param already implemented in #22); #22 and #16 both `approved` but MM-side is complete — remaining work is in change-planner and agile-toolkit.github.io repos respectively

--- a/src/components/TeamSession.tsx
+++ b/src/components/TeamSession.tsx
@@ -145,10 +145,23 @@ function IndividualComparisonGrid({
 function SessionHistoryPanel() {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
+  const [view, setView] = useState<'list' | 'trend'>('list')
   const history: TeamSessionHistoryEntry[] = JSON.parse(
     localStorage.getItem('moving-motivators:teamSessionHistory') || '[]'
   )
   if (history.length === 0) return null
+
+  // Compute top-3 appearance frequency per motivator across all stored sessions
+  const freq: Partial<Record<MotivatorId, number>> = {}
+  for (const entry of history) {
+    for (const id of entry.topMotivators) {
+      freq[id] = (freq[id] ?? 0) + 1
+    }
+  }
+  const trendRows = MOTIVATOR_ORDER
+    .map(id => ({ id, count: freq[id] ?? 0 }))
+    .sort((a, b) => b.count - a.count)
+  const maxCount = trendRows[0]?.count || 1
 
   return (
     <div className="flex flex-col gap-2">
@@ -160,36 +173,95 @@ function SessionHistoryPanel() {
         <span className="text-gray-400 dark:text-gray-600">{open ? '▲' : '▼'}</span>
       </button>
       {open && (
-        <div className="flex flex-col gap-2">
-          {history.map((entry, i) => (
-            <div
-              key={`${entry.sessionId}-${i}`}
-              className="bg-white dark:bg-gray-900 border border-gray-100 dark:border-gray-800 rounded-xl px-4 py-3 flex flex-col gap-1.5"
+        <div className="flex flex-col gap-3">
+          {/* View toggle */}
+          <div className="flex gap-1 bg-gray-100 dark:bg-gray-800 rounded-lg p-1">
+            <button
+              onClick={() => setView('list')}
+              className={`flex-1 text-xs py-1.5 rounded-md font-medium transition-colors ${
+                view === 'list'
+                  ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm'
+                  : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+              }`}
             >
-              <div className="flex items-baseline justify-between gap-2">
-                <span className="font-mono text-sm font-semibold text-brand-600 dark:text-brand-400">
-                  PIN {entry.teamName}
-                </span>
-                <span className="text-xs text-gray-400 dark:text-gray-600">{entry.date}</span>
-              </div>
-              <div className="flex items-center gap-1.5 flex-wrap">
-                {entry.topMotivators.map(id => {
-                  const meta = getMotivatorMeta(id)
-                  return (
-                    <span
-                      key={id}
-                      className={`inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full ${meta.color} ${meta.textColor} border ${meta.borderColor}`}
-                    >
-                      {meta.emoji} {t(`motivators.${id}.name`)}
+              {t('team.history.list')}
+            </button>
+            <button
+              onClick={() => setView('trend')}
+              className={`flex-1 text-xs py-1.5 rounded-md font-medium transition-colors ${
+                view === 'trend'
+                  ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm'
+                  : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+              }`}
+            >
+              {t('team.history.trend')}
+            </button>
+          </div>
+
+          {view === 'list' && (
+            <div className="flex flex-col gap-2">
+              {history.map((entry, i) => (
+                <div
+                  key={`${entry.sessionId}-${i}`}
+                  className="bg-white dark:bg-gray-900 border border-gray-100 dark:border-gray-800 rounded-xl px-4 py-3 flex flex-col gap-1.5"
+                >
+                  <div className="flex items-baseline justify-between gap-2">
+                    <span className="font-mono text-sm font-semibold text-brand-600 dark:text-brand-400">
+                      PIN {entry.teamName}
                     </span>
-                  )
-                })}
-              </div>
-              <span className="text-xs text-gray-400 dark:text-gray-600">
-                {entry.participantCount} {t('team.participants')}
-              </span>
+                    <span className="text-xs text-gray-400 dark:text-gray-600">{entry.date}</span>
+                  </div>
+                  <div className="flex items-center gap-1.5 flex-wrap">
+                    {entry.topMotivators.map(id => {
+                      const meta = getMotivatorMeta(id)
+                      return (
+                        <span
+                          key={id}
+                          className={`inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full ${meta.color} ${meta.textColor} border ${meta.borderColor}`}
+                        >
+                          {meta.emoji} {t(`motivators.${id}.name`)}
+                        </span>
+                      )
+                    })}
+                  </div>
+                  <span className="text-xs text-gray-400 dark:text-gray-600">
+                    {entry.participantCount} {t('team.participants')}
+                  </span>
+                </div>
+              ))}
             </div>
-          ))}
+          )}
+
+          {view === 'trend' && (
+            <div className="bg-white dark:bg-gray-900 border border-gray-100 dark:border-gray-800 rounded-xl px-4 py-3 flex flex-col gap-1">
+              <p className="text-xs text-gray-400 dark:text-gray-500 mb-2">
+                {t('team.history.topMotivators')} ({history.length} {t('team.history.sessions')})
+              </p>
+              {trendRows.map(({ id, count }) => {
+                const meta = getMotivatorMeta(id)
+                const pct = count === 0 ? 0 : Math.round((count / maxCount) * 100)
+                return (
+                  <div key={id} className="flex items-center gap-2 py-0.5">
+                    <span className="w-5 text-center text-base">{meta.emoji}</span>
+                    <span className={`w-20 text-xs font-medium truncate ${count > 0 ? meta.textColor : 'text-gray-300 dark:text-gray-700'}`}>
+                      {t(`motivators.${id}.name`)}
+                    </span>
+                    <div className="flex-1 h-4 bg-gray-100 dark:bg-gray-800 rounded-full overflow-hidden">
+                      {count > 0 && (
+                        <div
+                          className={`h-full rounded-full ${meta.color}`}
+                          style={{ width: `${pct}%` }}
+                        />
+                      )}
+                    </div>
+                    <span className={`w-6 text-right text-xs font-mono font-semibold ${count > 0 ? meta.textColor : 'text-gray-300 dark:text-gray-700'}`}>
+                      {count}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/i18n/be.json
+++ b/src/i18n/be.json
@@ -135,6 +135,12 @@
     "scanToJoin": "Сканаваць для далучэння",
     "sessionHistory": {
       "title": "Мінулыя камандныя сесіі"
+    },
+    "history": {
+      "list": "Спіс",
+      "trend": "Трэнд",
+      "topMotivators": "Частата топ-матыватараў",
+      "sessions": "сесій"
     }
   },
   "motivators": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -135,6 +135,12 @@
     "scanToJoin": "Scan to join",
     "sessionHistory": {
       "title": "Past Team Sessions"
+    },
+    "history": {
+      "list": "List",
+      "trend": "Trend",
+      "topMotivators": "Top motivator frequency",
+      "sessions": "sessions"
     }
   },
   "motivators": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -135,6 +135,12 @@
     "scanToJoin": "Escanear para unirse",
     "sessionHistory": {
       "title": "Sesiones de equipo anteriores"
+    },
+    "history": {
+      "list": "Lista",
+      "trend": "Tendencia",
+      "topMotivators": "Frecuencia de motivadores principales",
+      "sessions": "sesiones"
     }
   },
   "motivators": {

--- a/src/i18n/ru.json
+++ b/src/i18n/ru.json
@@ -135,6 +135,12 @@
     "scanToJoin": "Сканировать для входа",
     "sessionHistory": {
       "title": "Прошлые командные сессии"
+    },
+    "history": {
+      "list": "Список",
+      "trend": "Тренд",
+      "topMotivators": "Частота топ-мотиваторов",
+      "sessions": "сессий"
     }
   },
   "motivators": {


### PR DESCRIPTION
Automated agent commit — see BRIEF.md.

Adds a List/Trend toggle to `SessionHistoryPanel` in `TeamSession.tsx`. The trend view computes how many times each CHAMPFROGS motivator appeared in the top 3 across all stored team sessions (`moving-motivators:teamSessionHistory`) and renders a frequency bar chart sorted by count descending. Each motivator uses its brand color; zero-count motivators are greyed out.

Also auto-approves issues #47 and #48 (8 days stale, Research type, threshold is 7 days).

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6R944RzzYSqEk8Lr2RV9q)_