### PR TITLE
docs: define goal and roadmap

### DIFF
--- a/.artefacts/GOAL.md
+++ b/.artefacts/GOAL.md
@@ -1,0 +1,20 @@
+# Moving Motivators — Goal
+
+## Problem
+Teams and individuals practicing agile / Management 3.0 need a fast, low-friction way to surface intrinsic motivators (the CHAMPFROGS model: Curiosity, Honor, Acceptance, Mastery, Power, Freedom, Relatedness, Order, Goal, Status) and assess how a proposed change affects each one — either as a private solo self-reflection or as a live, facilitated team workshop — without physical card decks, accounts, or specialized software.
+
+## Audience
+Individual contributors doing solo self-reflection before or after a change; Scrum Masters and facilitators running a live team workshop (in-person or remote, joined by PIN); teams inside the wider agile-toolkit suite who want motivator context to feed into change-management, retro, and profile tools they already use.
+
+## Success criteria
+1. A user can rank all ten CHAMPFROGS motivators solo, assess a proposed change's impact on each, and see interpreted results in a few minutes with no account or setup.
+2. A facilitator can host a live team session via PIN, participants join and rank independently, and the facilitator reveals aggregate + individual results synced in real time (Firebase).
+3. Solo and team session history persists across visits so users and facilitators can see motivator shifts and trends over multiple sessions.
+4. Results can be exported or shared (image, JSON, print) and handed off in-context to other suite apps (Change Planner, Sprint Metrics, Work Profiles) via URL param or localStorage snapshot.
+5. The app works fully offline for solo mode (PWA) and is fully operable by keyboard (WCAG-compliant ranking interaction).
+
+## Non-goals
+- Not a general-purpose survey/poll builder — the motivator set is fixed to CHAMPFROGS, not user-definable.
+- No persistent multi-user accounts or server-side profiles — team sessions are ephemeral and PIN-scoped only.
+- Not a full change-management platform — the Change Planner integration is a context handoff (URL param snapshot), not a merged product.
+- No native mobile app — responsive web only.

--- a/.artefacts/ROADMAP.md
+++ b/.artefacts/ROADMAP.md
@@ -1,0 +1,28 @@
+# Moving Motivators — Roadmap
+
+Derived from GOAL.md. Rebuilt when GOAL changes or an epic ships.
+
+## Current epic
+None — idle. See `## Next epics` below.
+
+## Next epics
+1. **E1: Team Identity name handoff** — serves #2. Read `team-identity:draft` on host mount and offer a one-click "use this team's name" suggestion in the team session lobby, replacing the raw PIN as the display name in stored history. [#51](https://github.com/agile-toolkit/moving-motivators/issues/51)
+2. **E2: Personalized results coaching** — serves #1. Add a collapsible tips panel in `ResultsView` that surfaces 2-3 short, personalized coaching notes based on the user's top 3 motivators and their change-assessment outcome, so solo results give interpretation, not just a raw ranking. [#52](https://github.com/agile-toolkit/moving-motivators/issues/52)
+
+Both issues are `needs-review` and past the 7-day staleness threshold (open since 2026-06-26 and 2026-06-29 respectively, as of 2026-07-25) — eligible for auto-approval on the next research/build cycle per the pipeline's stale-issue convention.
+
+## Polish backlog
+- Favicon fix — `public/favicon.svg` is corrupted; a finalized teal `#0d9488` descending-bars SVG design is ready, awaiting the `approved` label. [#5](https://github.com/agile-toolkit/moving-motivators/issues/5)
+- Two open issues have no remaining work in *this* repo: [#16](https://github.com/agile-toolkit/moving-motivators/issues/16) (Dashboard card reader lives in `agile-toolkit.github.io`) and [#53](https://github.com/agile-toolkit/moving-motivators/issues/53) (Improvement Board deep link needs zero Moving Motivators changes — `?change=` param already exists from #22). [#22](https://github.com/agile-toolkit/moving-motivators/issues/22)'s Change Planner-side sidebar is likewise pending in the `change-planner` repo, not here.
+
+## Shipped
+- ~~Solo mode: rank CHAMPFROGS motivators, assess a change's impact, interpreted results~~
+- ~~Team mode: host/join via PIN, Firebase realtime sync, phase-aware facilitator timer~~
+- ~~4-language i18n (EN/ES/BE/RU) with header language picker~~
+- ~~Light/dark theme and unified AppHeader/LanguagePicker design-system components~~
+- ~~Keyboard-accessible drag-and-drop ranking (WCAG 2.1.1)~~
+- ~~Solo + team session history — shift/trend views, save/restore, JSON export & import~~
+- ~~Share results as image, print/PDF export, QR code team join~~
+- ~~PWA / offline support for workshop use~~
+- ~~Suite integrations: Work Profiles, Sprint Metrics, Change Planner (Moving Motivators side)~~
+- ~~First-run onboarding content in the "About this exercise" panel~~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+## Unreleased
+
+- **docs**: added `.artefacts/GOAL.md` and `.artefacts/ROADMAP.md`, and filled in `README.md` with dev commands, a localStorage keys table, and tech notes. Docs-only — no behavior change; documents functionality that previously only lived in `.artefacts/BRIEF.md`.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 **Live app:** https://bthos.github.io/moving-motivators/
 
+> See [`.artefacts/GOAL.md`](.artefacts/GOAL.md) for why this app exists and [`.artefacts/ROADMAP.md`](.artefacts/ROADMAP.md) for what's next.
+
 ---
 
 ## What is Moving Motivators?
@@ -61,6 +63,15 @@ npm run dev
 
 Open http://localhost:5173/moving-motivators/
 
+### Dev commands
+
+| Command | Purpose |
+|---------|---------|
+| `npm run dev` | Start the Vite dev server |
+| `npm run build` | Type-check (`tsc`) then production build (`vite build`) |
+| `npm run preview` | Serve the production build locally |
+| `npm test` | Run the test suite (`vitest run`) |
+
 ### Environment variables (optional — for team mode)
 
 Copy `.env.example` to `.env.local` and fill in your Firebase project values:
@@ -100,6 +111,32 @@ To deploy from a fork:
 | Realtime | Firebase Realtime Database |
 | CI/CD | GitHub Actions → GitHub Pages |
 | Dev pipeline | [agentic-kit](https://github.com/bthos/agentic-kit) (submodule) |
+
+---
+
+## localStorage keys
+
+All keys are namespaced `moving-motivators:*` except two shared-pattern keys (`theme`, `mm_about_dismissed`) and one cross-app key this app writes on behalf of Work Profiles.
+
+| Key | Shape | Purpose |
+|-----|-------|---------|
+| `moving-motivators:lastSession` | `{ date, savedAt, ranked: MotivatorId[], change: string, changes: Record<MotivatorId, ImpactLevel> }` | Most recent solo session; written on the ranking/assessment → results transition. Read by the suite Dashboard card reader. |
+| `moving-motivators:sessionHistory` | `Array<{ label?: string, date, savedAt, ranked: MotivatorId[], change: string, changes }>` (newest first, capped at 20) | Solo session history behind the shift/trend views, export, import, and "Save as…" naming in `ResultsView.tsx`. |
+| `moving-motivators:motivationSnapshot` | `{ teamName: string (PIN), date, topMotivators: MotivatorId[3], participantCount }` | Aggregate top-3 snapshot written by the host when a team session is revealed; read by the "Send to Sprint Metrics" deep link. |
+| `moving-motivators:teamSessionHistory` | `Array<{ sessionId, teamName, date, topMotivators: MotivatorId[3], participantCount }>` (newest first, capped at 10) | Revealed team sessions behind `SessionHistoryPanel`'s list/trend view, export, and import. |
+| `work-profiles:motivatorSnapshot` | `{ date, ranked: MotivatorId[], topMotivators: MotivatorId[3] }` | Written by this app's "Export to Work Profiles" button — owned/read by the Work Profiles app, not Moving Motivators itself. |
+| `theme` | `'light' \| 'dark'` | Shared `ThemeToggle` component's stored preference (same key pattern used by other suite apps, scoped per-origin). |
+| `mm_about_dismissed` | `'1'` once dismissed | Marks the HomeScreen "About this exercise" panel as dismissed so it doesn't default open on return visits. |
+
+## Tech notes
+
+- **State**: no global store — screen/session state lives in `App.tsx` component state and is passed down as props; persistence is plain `localStorage.setItem`/`getItem` calls at the transition points listed above, not a data layer.
+- **i18n**: `react-i18next` with four complete locales (`src/i18n/{en,es,be,ru}.json`); the header language picker cycles all four. New UI strings must be added to all four files in the same run.
+- **Theme**: Tailwind `darkMode: 'class'`; an anti-flash inline script in `index.html` applies the stored `theme` class before first paint; `dark:` variants are hand-added per component (`design-system/tokens.css` token map).
+- **Team realtime**: Firebase Realtime Database, optional — configured via `VITE_FIREBASE_*` env vars. Solo mode and the whole build work with zero Firebase config; `HomeScreen` disables team buttons when Firebase isn't configured or the app is offline.
+- **PWA**: `vite-plugin-pwa` (`generateSW` strategy) caches the app shell, static assets, and Google Fonts; a `useOnlineStatus()` hook in `App.tsx` drives an offline banner and disables team-session actions while offline.
+- **Cross-app integrations**: writes `work-profiles:motivatorSnapshot` for Work Profiles and `moving-motivators:motivationSnapshot` for Sprint Metrics; opens Change Planner with a base64-encoded snapshot in `?mm_snapshot=` and reads `?change=`/`?join=` URL params on load from Change Planner and QR-code team invites respectively. All are one-way, URL/localStorage-only handoffs — no shared backend.
+- **Submodule note**: `.gitmodules` references `agentic-kit` (dev-pipeline tooling only); it is not fetched or required by the CI build (`.github/workflows/deploy.yml` does not use `submodules: recursive`).
 
 ---
 


### PR DESCRIPTION
## Summary

Docs-only pass to bring this repo's agent-maintained docs up to the same standard as `agile-toolkit.github.io`:

- Add `.artefacts/GOAL.md` — problem, audience, success criteria, non-goals (extracted from `.artefacts/BRIEF.md`).
- Add `.artefacts/ROADMAP.md` — current epic (none), next epics (issues [#51](https://github.com/agile-toolkit/moving-motivators/issues/51) and [#52](https://github.com/agile-toolkit/moving-motivators/issues/52), both stale `needs-review`), polish backlog, and a synthesized shipped list.
- Update `README.md` — link to the new `.artefacts` docs, add a "Dev commands" table, a `## localStorage keys` table, and a `## Tech notes` section.
- Add `CHANGELOG.md` with an `## Unreleased` entry for this docs-only change.

`.artefacts/BRIEF.md` is untouched — it remains the human-authored feature checklist + run log.

No source code, build config, or dependency changes. `package-lock.json` had a pre-existing local modification in the working tree that this PR does **not** include.

## Test plan

- [x] Docs-only diff — no code paths changed.
- [x] Confirmed `.artefacts/GOAL.md` and `.artefacts/ROADMAP.md` were force-added past `.gitignore`'s `.artefacts/*` rule (same pattern as `!.artefacts/BRIEF.md`), matching the sibling `agile-toolkit.github.io` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqHwojggZNH6G3ZhoqjhiW

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqHwojggZNH6G3ZhoqjhiW)_